### PR TITLE
Fix autosorting behaviour

### DIFF
--- a/scripts/autosorting.js
+++ b/scripts/autosorting.js
@@ -45,24 +45,19 @@ export function registerSortingConfig() {
 
 }
 
-
-
-
-
 function calculateTokenSortValue(token) {
-  const scene = game.scenes.active;
-  if (!scene) return token.sort;
+  const dimensions = canvas.scene.dimensions;
 
-  // Gets the dimensions of the canvas
-  const { width, height } = scene;
+  const { width, height } = dimensions;
 
-  // Calculates the sort value using the X+Y method. Those are all methods to prioritize each corner (but the only who matter to isometric is south).
-  return Math.floor((width - token.x) + token.y);                // South
-  //return Math.floor(token.x + (height - token.y));             // North
-  //return Math.floor(token.x + token.y);                        // East
-  //return Math.floor((width - token.x) + (height - token.y));   // West
+  // invert the x because the co-ordinate system doesn't match our intuition for "closer to the screen"
+  const tokenX = width - token.x;
+  const tokenY = token.y;
+
+  const sortValue = Math.round(((tokenX + tokenY) / (width + height)) * 10000);
+
+  return sortValue;
 }
-
 
 async function updateTokenSort(token) {
   const scene = game.scenes.active;


### PR DESCRIPTION
Edit: clarified the actual main difference in this implementation

Fixes #2's lingering bugs.

## Summary
This PR fixes the sorting behaviour in the "autosorting" beta feature. 

## Explanation

Rather than just adding x and y, we sort by the fraction of our X + Y of the total span of width + height. This gives us a measure of how "close" we are to the relevant corner of the screen. We also scale the number by an arbitrary value so that our rounding works out nicely and we have a cap. Essentially we are linearly interpolating our sort value based on the fraction of the way towards the corner our token is.

Because our +x is actually "further" from us in foundry's co-ordinate system we also still need to invert the x (by subtracting it from the canvas width) in order to get an accurate X+Y sort for our purposes.

## Testing

Checkout the branch or otherwise get the changed code into your local module, drag some new tokens in and move them around eachother in circles.

## Before

https://github.com/user-attachments/assets/3aa0d499-22db-4d8c-a94a-0700d306c8fd


## After

https://github.com/user-attachments/assets/f890cb14-0313-4c16-a6dd-f63b2bfcc36c

## Thoughts
We could experiment with other numbers to multiply by, I'm not sure if having a large sort number has any knock-on effects we need to worry about. A large number garauntees we never accidentally sort adjacent tokens onto the same layer though.

