### PR TITLE
When un-setting the mesh anchor, try to use the document's configured anchors

### DIFF
--- a/scripts/token.js
+++ b/scripts/token.js
@@ -177,8 +177,6 @@ async function handleRenderTokenConfig(app, html, data) {
     event.preventDefault(); // Evita que o clique feche a janela
 
     // Reset all alignment settings
-    html.find('input[name="texture.anchorX"]').val(0.5);
-    html.find('input[name="texture.anchorY"]').val(0.5);
     html.find('input[name="flags.isometric-perspective.isoAnchorX"]').val(0.5);
     html.find('input[name="flags.isometric-perspective.isoAnchorY"]').val(0.5);
     html.find('input[name="flags.isometric-perspective.offsetX"]').val(0);
@@ -212,24 +210,6 @@ async function handleRenderTokenConfig(app, html, data) {
   });
 
   
-  
-  
-
-
-  // Removes all lines when clicking on update token
-  html.find('button[type="submit"]').on('click', () => {
-    if (!isoAnchorToggleCheckbox.prop("checked")) {
-      cleanup();
-    } else {
-      // Take updated values ​​directly from inputs
-      let currentIsoAnchorX = html.find('input[name="flags.isometric-perspective.isoAnchorX"]').val();
-      let currentIsoAnchorY = html.find('input[name="flags.isometric-perspective.isoAnchorY"]').val();
-      
-      // Update the anchor basic values ​​in the token configuration
-      html.find('input[name="texture.anchorX"]').val(currentIsoAnchorY);
-      html.find('input[name="texture.anchorY"]').val(1-currentIsoAnchorX);
-    }
-  });
 
   // Changes the Close method to delete the lines, IF avoids changing the method more than once
   if (!app._isCloseModified) {

--- a/scripts/token.js
+++ b/scripts/token.js
@@ -18,8 +18,8 @@ async function handleRenderTokenConfig(app, html, data) {
     isoDisabled: app.object.getFlag(MODULE_ID, 'isoTokenDisabled') ?? 1,
     offsetX: app.object.getFlag(MODULE_ID, 'offsetX') ?? 0,
     offsetY: app.object.getFlag(MODULE_ID, 'offsetY') ?? 0,
-    isoAnchorY: app.object.getFlag(MODULE_ID, 'isoAnchorY') ?? 0,
-    isoAnchorX: app.object.getFlag(MODULE_ID, 'isoAnchorX') ?? 0,
+    isoAnchorY: app.object.getFlag(MODULE_ID, 'isoAnchorY') ?? 0.5,
+    isoAnchorX: app.object.getFlag(MODULE_ID, 'isoAnchorX') ?? 0.5,
     isoAnchorToggleCheckbox: app.object.getFlag(MODULE_ID, 'isoAnchorToggle') ?? 0,
     scale: app.object.getFlag(MODULE_ID, 'scale') ?? 1
   });
@@ -123,7 +123,7 @@ async function handleRenderTokenConfig(app, html, data) {
 
   // Function to calculate the alignment point
   function updateIsoAnchor(isoAnchorX, isoAnchorY, offsetX, offsetY) {
-    let tokenMesh = app.token.object.mesh;
+    let tokenMesh = app.token.object?.mesh;
     if (!tokenMesh) return { x: 0, y: 0 };
     
     // Defines the values ​​and transforms strings into numbers
@@ -156,8 +156,8 @@ async function handleRenderTokenConfig(app, html, data) {
 
   
   // Initialize the lines with the current values
-  let isoAnchorX = app.object.getFlag(MODULE_ID, 'isoAnchorX') ?? 0;
-  let isoAnchorY = app.object.getFlag(MODULE_ID, 'isoAnchorY') ?? 0;
+  let isoAnchorX = app.object.getFlag(MODULE_ID, 'isoAnchorX') ?? 0.5;
+  let isoAnchorY = app.object.getFlag(MODULE_ID, 'isoAnchorY') ?? 0.5;
   let offsetX = app.object.getFlag(MODULE_ID, 'offsetX') ?? 0;
   let offsetY = app.object.getFlag(MODULE_ID, 'offsetY') ?? 0;
   

--- a/scripts/transform.js
+++ b/scripts/transform.js
@@ -115,9 +115,11 @@ export function applyIsometricTransformation(object, isSceneIsometric) {
   }
 
   // It undoes rotation and deformation
+  let isoAnchorX = object.document.getFlag(MODULE_ID, "isoAnchorX") ?? 0.5;
+  let isoAnchorY = object.document.getFlag(MODULE_ID, "isoAnchorY") ?? 0.5;
   object.mesh.rotation = Math.PI/4;
   object.mesh.skew.set(0, 0);
-  //object.mesh.anchor.set(isoAnchorX, isoAnchorY);
+  object.mesh.anchor.set(isoAnchorX, isoAnchorY);
     
   // recovers the object characteristics of the object (token/tile)
   let texture = object.texture;

--- a/scripts/transform.js
+++ b/scripts/transform.js
@@ -92,7 +92,10 @@ export function applyIsometricTransformation(object, isSceneIsometric) {
   let isoTileDisabled = object.document.getFlag(MODULE_ID, 'isoTileDisabled') ?? 0;
   let isoTokenDisabled = object.document.getFlag(MODULE_ID, 'isoTokenDisabled') ?? 0;
   if (isoTileDisabled || isoTokenDisabled) {
-    object.mesh.anchor.set(0.5, 0.5);  // This is set to make isometric anchor don't mess with non-iso scenes
+    object.mesh.anchor.set(
+      object?.document?.texture?.anchorX ?? 0.5,
+      object?.document?.texture?.anchorY ?? 0.5
+    );  // This is set to make isometric anchor don't mess with non-iso scenes
     return
   }
 
@@ -104,7 +107,10 @@ export function applyIsometricTransformation(object, isSceneIsometric) {
     //object.mesh.scale.set(objTxtRatio, objTxtRatio);
     //object.mesh.position.set(object.document.x, object.document.y);
     //object.document.texture.fit = "contain"; //height
-    object.mesh.anchor.set(0.5, 0.5);  // This is set to make isometric anchor don't mess with non-iso scenes
+    object.mesh.anchor.set(
+      object?.document?.texture?.anchorX ?? 0.5,
+      object?.document?.texture?.anchorY ?? 0.5
+    );  // This is set to make isometric anchor don't mess with non-iso scenes
     return;
   }
 

--- a/templates/token-config.html
+++ b/templates/token-config.html
@@ -30,7 +30,6 @@
     <label>{{localize 'isometric-perspective.token_isoAnchor_name'}}</label>
     <div class="form-fields">
       <label class="anchorToggle">{{localize 'isometric-perspective.token_isoAnchor_save'}}</label>
-      <input type="checkbox" name="isoAnchorToggle" {{#if isoAnchorToggle}}unchecked{{/if}}>
       <label class="axisX">X</label>
       <input type="number" name="flags.isometric-perspective.isoAnchorY" 
              value="{{isoAnchorY}}"


### PR DESCRIPTION
When you have a token on a non-isometric scene which defines an anchor, enabling this module overrides the anchor even on scenes that don't have isometric enabled.