### PR TITLE
Revert "When un-setting the mesh anchor, try to use the document's configured anchors"

### DIFF
--- a/scripts/token.js
+++ b/scripts/token.js
@@ -19,8 +19,8 @@ async function handleRenderTokenConfig(app, html, data) {
     isoDisabled: app.object.getFlag(MODULE_ID, 'isoTokenDisabled') ?? 1,
     offsetX: app.object.getFlag(MODULE_ID, 'offsetX') ?? 0,
     offsetY: app.object.getFlag(MODULE_ID, 'offsetY') ?? 0,
-    isoAnchorY: app.object.getFlag(MODULE_ID, 'isoAnchorY') ?? 0.5,
-    isoAnchorX: app.object.getFlag(MODULE_ID, 'isoAnchorX') ?? 0.5,
+    isoAnchorY: app.object.getFlag(MODULE_ID, 'isoAnchorY') ?? 0,
+    isoAnchorX: app.object.getFlag(MODULE_ID, 'isoAnchorX') ?? 0,
     isoAnchorToggleCheckbox: app.object.getFlag(MODULE_ID, 'isoAnchorToggle') ?? 0,
     scale: app.object.getFlag(MODULE_ID, 'scale') ?? 1
   });
@@ -124,7 +124,7 @@ async function handleRenderTokenConfig(app, html, data) {
 
   // Function to calculate the alignment point
   function updateIsoAnchor(isoAnchorX, isoAnchorY, offsetX, offsetY) {
-    let tokenMesh = app.token.object?.mesh;
+    let tokenMesh = app.token.object.mesh;
     if (!tokenMesh) return { x: 0, y: 0 };
     
     // Defines the values ​​and transforms strings into numbers
@@ -157,8 +157,8 @@ async function handleRenderTokenConfig(app, html, data) {
 
   
   // Initialize the lines with the current values
-  let isoAnchorX = app.object.getFlag(MODULE_ID, 'isoAnchorX') ?? 0.5;
-  let isoAnchorY = app.object.getFlag(MODULE_ID, 'isoAnchorY') ?? 0.5;
+  let isoAnchorX = app.object.getFlag(MODULE_ID, 'isoAnchorX') ?? 0;
+  let isoAnchorY = app.object.getFlag(MODULE_ID, 'isoAnchorY') ?? 0;
   let offsetX = app.object.getFlag(MODULE_ID, 'offsetX') ?? 0;
   let offsetY = app.object.getFlag(MODULE_ID, 'offsetY') ?? 0;
   
@@ -178,6 +178,8 @@ async function handleRenderTokenConfig(app, html, data) {
     event.preventDefault(); // Evita que o clique feche a janela
 
     // Reset all alignment settings
+    html.find('input[name="texture.anchorX"]').val(0.5);
+    html.find('input[name="texture.anchorY"]').val(0.5);
     html.find('input[name="flags.isometric-perspective.isoAnchorX"]').val(0.5);
     html.find('input[name="flags.isometric-perspective.isoAnchorY"]').val(0.5);
     html.find('input[name="flags.isometric-perspective.offsetX"]').val(0);
@@ -211,6 +213,24 @@ async function handleRenderTokenConfig(app, html, data) {
   });
 
   
+  
+  
+
+
+  // Removes all lines when clicking on update token
+  html.find('button[type="submit"]').on('click', () => {
+    if (!isoAnchorToggleCheckbox.prop("checked")) {
+      cleanup();
+    } else {
+      // Take updated values ​​directly from inputs
+      let currentIsoAnchorX = html.find('input[name="flags.isometric-perspective.isoAnchorX"]').val();
+      let currentIsoAnchorY = html.find('input[name="flags.isometric-perspective.isoAnchorY"]').val();
+      
+      // Update the anchor basic values ​​in the token configuration
+      html.find('input[name="texture.anchorX"]').val(currentIsoAnchorY);
+      html.find('input[name="texture.anchorY"]').val(1-currentIsoAnchorX);
+    }
+  });
 
   // Changes the Close method to delete the lines, IF avoids changing the method more than once
   if (!app._isCloseModified) {

--- a/scripts/transform.js
+++ b/scripts/transform.js
@@ -56,10 +56,7 @@ export function applyIsometricTransformation(object, isSceneIsometric) {
   let isoTileDisabled = object.document.getFlag(MODULE_ID, 'isoTileDisabled') ?? 0;
   let isoTokenDisabled = object.document.getFlag(MODULE_ID, 'isoTokenDisabled') ?? 0;
   if (isoTileDisabled || isoTokenDisabled) {
-    object.mesh.anchor.set(
-      object?.document?.texture?.anchorX ?? 0.5,
-      object?.document?.texture?.anchorY ?? 0.5
-    );  // This is set to make isometric anchor don't mess with non-iso scenes
+    object.mesh.anchor.set(0.5, 0.5);  // This is set to make isometric anchor don't mess with non-iso scenes
     return
   }
 
@@ -71,19 +68,14 @@ export function applyIsometricTransformation(object, isSceneIsometric) {
     //object.mesh.scale.set(objTxtRatio, objTxtRatio);
     //object.mesh.position.set(object.document.x, object.document.y);
     //object.document.texture.fit = "contain"; //height
-    object.mesh.anchor.set(
-      object?.document?.texture?.anchorX ?? 0.5,
-      object?.document?.texture?.anchorY ?? 0.5
-    );  // This is set to make isometric anchor don't mess with non-iso scenes
+    object.mesh.anchor.set(0.5, 0.5);  // This is set to make isometric anchor don't mess with non-iso scenes
     return;
   }
 
   // It undoes rotation and deformation
-  let isoAnchorX = object.document.getFlag(MODULE_ID, "isoAnchorX") ?? 0.5;
-  let isoAnchorY = object.document.getFlag(MODULE_ID, "isoAnchorY") ?? 0.5;
   object.mesh.rotation = ISOMETRIC_CONST.reverseRotation;
   object.mesh.skew.set(ISOMETRIC_CONST.reverseSkewX, ISOMETRIC_CONST.reverseSkewY);
-  object.mesh.anchor.set(isoAnchorX, isoAnchorY);
+  //object.mesh.anchor.set(isoAnchorX, isoAnchorY);
     
   // recovers the object characteristics of the object (token/tile)
   let texture = object.texture;

--- a/templates/token-config.html
+++ b/templates/token-config.html
@@ -30,6 +30,7 @@
     <label>{{localize 'isometric-perspective.token_isoAnchor_name'}}</label>
     <div class="form-fields">
       <label class="anchorToggle">{{localize 'isometric-perspective.token_isoAnchor_save'}}</label>
+      <input type="checkbox" name="isoAnchorToggle" {{#if isoAnchorToggle}}unchecked{{/if}}>
       <label class="axisX">X</label>
       <input type="number" name="flags.isometric-perspective.isoAnchorY" 
              value="{{isoAnchorY}}"


### PR DESCRIPTION
Reverts arlosmolten/isometric-perspective#9

These changes breaks the aligment tool. While using, the anchor shouldn't be updated, cause the token will be moving too.