### PR TITLE
V14 depth sorting beta v3

### DIFF
--- a/lang/en.json
+++ b/lang/en.json
@@ -12,6 +12,8 @@
     "isometric-perspective.settings_dynamic_tile_hint": "(BETA FEATURE. USE WITH CAUTION) Adjusts the visibility of tiles dynamically with the positioning of tokens. See how this feature works here.",
     "isometric-perspective.settings_token_sort_name": "Enable Automatic Token Sorting",
     "isometric-perspective.settings_token_sort_hint": "(BETA FEATURE. USE WITH CAUTION. V12+ ONLY) Automatically adjusts the tokens sort property value when moving it around the canvas.",
+    "isometric-perspective.settings_toggle_depth_sort_active": "Toggle depth sort",
+    "isometric-perspective.settings_toggle_depth_sort_active_hint": "Toggle depth sort for newly created tiles while active.",
     "isometric-perspective.settings_token_silhouette_name": "Enable Occlusion: Token Silhouette",
     "isometric-perspective.settings_token_silhouette_hint": "(BETA FEATURE WITH PERFORMANCE ISSUES. USE SPARENTLY) Creates a shadow effect on the token when behind a tile. GPU mode isn't working properly, but it is lightning fast. CPU is always heavy in processing, but a higher chunk option is faster trading quality fidelity. 'Chunk Size = 2' is the probably the better mode.",
     "isometric-perspective.settings_welcome_name": "Show Welcome Screen",

--- a/lang/pt-BR.json
+++ b/lang/pt-BR.json
@@ -12,6 +12,8 @@
     "isometric-perspective.settings_dynamic_tile_hint": "(RECURSO EM TESTES. USE COM CUIDADO) Ajusta a visibilidade dos tiles dinamicamente com a posição dos tokens. Veja como esta funcionalidade funciona aqui.",
     "isometric-perspective.settings_token_sort_name": "Habilitar Ordenação Automática de Tokens",
     "isometric-perspective.settings_token_sort_hint": "(RECURSO EM TESTES. USE COM CUIDADO. SOMENTE PARA V12+) Ajusta automaticamente o valor de ordenação dos tokens ao movê-los pelo canvas.",
+    "isometric-perspective.settings_toggle_depth_sort_active": "Toggle depth sort",
+    "isometric-perspective.settings_toggle_depth_sort_active_hint": "Toggle depth sort for newly created tiles while active.", 
     "isometric-perspective.settings_token_silhouette_name": "Habilitar Oclusão: Silhueta de Token",
     "isometric-perspective.settings_token_silhouette_hint": "(RECURSO EM TESTES COM PROBLEMAS DE PERFORMANCE. USE DE FORMA LEVE) Cria um efeito de sombra sobre o token que estiver por trás de um tile. GPU não está funcionando corretamente, mas é super rápido. CPU é sempre pesado no processamento, mas é possível diminuir o impacto escolhendo um valor de chunk maior. 'Chunk Size = 2' é provavelmente a melhor opção.",
     "isometric-perspective.settings_welcome_name": "Mostrar Janela de Boas-Vindas",

--- a/scripts/autosorting.js
+++ b/scripts/autosorting.js
@@ -4,41 +4,30 @@ import {
   isIsometricAutosortingEnabledForPlaceable
 } from './utils.js';
 
-export async function isoDepthSortReady(){
-  const scene = canvas.scene;
-  if (!scene ||!canvas.ready) return;
-  const tokens = scene.tokens;
-  const updates = tokens.map(tokenDocument => {
-    const token = tokenDocument.object;
-    const updateList =[];
-
-    if (token !== null){
-      if(isIsometricAutosortingEnabledForPlaceable(token,scene)){
-        const newSort = comparePlaceablePosition(token);
-        if (tokenDocument.sort!== newSort) {
-          updateList.push({
-            _id: token.id,
-            sort: newSort
-          });
-        }
+export function isoDepthSortMixin(Base){  
+  return class DepthSortPlaceable extends Base{
+    _refreshState() {
+      super._refreshState();
+      const sortableType = this.name.split(".").shift();
+      const newSort = comparePlaceablePosition(this);
+      if(sortableType === "Token"){
+        async () => await awaitTokenAnimation(this.document);
+        this.sort = newSort;
+        this.mesh.sort = newSort;
+      } else {
+        this.sort = newSort;
+        this.mesh.sort = newSort;
       }
     }
-    return updateList
-  })
-  const validUpdates = updates.filter(update => update._id && update._id!== "");
-  if (updates.length > 0) {
-    await scene.updateEmbeddedDocuments('Token', validUpdates);
   }
 }
 
 export async function isoDepthSort(placeable,scene,label){   
     await awaitTokenAnimation(placeable.document); 
     const newSort = comparePlaceablePosition(placeable);
-    const update = {
-      _id: placeable.document.id,
-      sort: newSort
-    };
-    await scene.updateEmbeddedDocuments(label, [update]); 
+    placeable.sort = newSort;
+    placeable.mesh.sort = newSort;
+    console.log("SORTING?", placeable.sort, placeable.mesh.sort);
 }
 
 /**
@@ -48,13 +37,11 @@ export async function isoDepthSort(placeable,scene,label){
 async function awaitTokenAnimation(document) {
   const token = document.object;
   if (!token) return;
-
   // wait for the token movement to end
   const movementAnim = token.animation || token.movementAnimationPromise;
   if (movementAnim) {
     try { await movementAnim; } catch (e) { /* Ignore interruptions */ }
   }
-
   // extra check if the token is moving on another level or between levels.
   if (token.levelIndicator?.animation) {
     try { await token.levelIndicator.animation; } catch (e) { }

--- a/scripts/autosorting.js
+++ b/scripts/autosorting.js
@@ -6,22 +6,29 @@ import {
 
 export async function isoDepthSortReady(){
   const scene = canvas.scene;
+  if (!scene ||!canvas.ready) return;
   const tokens = scene.tokens;
   const updates = tokens.map(tokenDocument => {
-    const token = canvas.tokens.get(tokenDocument.id);
-      if(isIsometricAutosortingEnabledForPlaceable(token)){
-        if (!token) return null;
+    const token = tokenDocument.object;
+    const updateList =[];
+
+    if (token !== null){
+      if(isIsometricAutosortingEnabledForPlaceable(token,scene)){
         const newSort = comparePlaceablePosition(token);
-        return {
-          _id: tokenDocument.id,
-          sort: newSort
-        };
+        if (tokenDocument.sort!== newSort) {
+          updateList.push({
+            _id: token.id,
+            sort: newSort
+          });
+        }
       }
-    }).filter(update => update !== null);
-  
-    if (updates.length > 0) {
-      scene.updateEmbeddedDocuments('Token', updates);
     }
+    return updateList
+  })
+  const validUpdates = updates.filter(update => update._id && update._id!== "");
+  if (updates.length > 0) {
+    await scene.updateEmbeddedDocuments('Token', validUpdates);
+  }
 }
 
 export async function isoDepthSort(placeable,scene,label){   
@@ -49,10 +56,10 @@ async function awaitTokenAnimation(document) {
   if (anim) {
     try { await anim; } catch (e) { /* Ignore interruptions */ }
   } else {
-    // Fallback: Check CanvasAnimation
-    if (CanvasAnimation && CanvasAnimation.animations) {
-      const animations = CanvasAnimation.animations;
-      // CanvasAnimation.animations can be an Object or Map depending on Foundry version
+    // Fallback: Check foundry.canvas.animation.CanvasAnimation
+    if (foundry.canvas.animation.CanvasAnimation && foundry.canvas.animation.CanvasAnimation.animations) {
+      const animations = foundry.canvas.animation.CanvasAnimation.animations;
+      // foundry.canvas.animation.CanvasAnimation.animations can be an Object or Map depending on Foundry version
       const entries = (animations instanceof Map) ? animations.entries() : Object.entries(animations);
 
       for (const [key, promiseData] of entries) {

--- a/scripts/autosorting.js
+++ b/scripts/autosorting.js
@@ -49,28 +49,14 @@ async function awaitTokenAnimation(document) {
   const token = document.object;
   if (!token) return;
 
-  // Give Foundry a tick to utilize animation properties
-  await new Promise(r => setTimeout(r, 0));
+  // wait for the token movement to end
+  const movementAnim = token.animation || token.movementAnimationPromise;
+  if (movementAnim) {
+    try { await movementAnim; } catch (e) { /* Ignore interruptions */ }
+  }
 
-  const anim = token.movementAnimationPromise || token.animation;
-  if (anim) {
-    try { await anim; } catch (e) { /* Ignore interruptions */ }
-  } else {
-    // Fallback: Check foundry.canvas.animation.CanvasAnimation
-    if (foundry.canvas.animation.CanvasAnimation && foundry.canvas.animation.CanvasAnimation.animations) {
-      const animations = foundry.canvas.animation.CanvasAnimation.animations;
-      // foundry.canvas.animation.CanvasAnimation.animations can be an Object or Map depending on Foundry version
-      const entries = (animations instanceof Map) ? animations.entries() : Object.entries(animations);
-
-      for (const [key, promiseData] of entries) {
-        if (key.includes(document.id)) {
-          // promiseData might be the promise itself or an object containing the promise
-          const promise = promiseData.promise || promiseData;
-          if (promise) {
-            try { await promise; } catch (e) { }
-          }
-        }
-      }
-    }
+  // extra check if the token is moving on another level or between levels.
+  if (token.levelIndicator?.animation) {
+    try { await token.levelIndicator.animation; } catch (e) { }
   }
 }

--- a/scripts/main.js
+++ b/scripts/main.js
@@ -16,6 +16,7 @@ import {
   handleCreateTile,
   handleUpdateTile,
   handleRefreshTile,
+  addDepthSortControls
  } from './tile.js';
 
 import { 
@@ -203,7 +204,7 @@ Hooks.once("init", function() {
 
   // ------------- Executa os hooks de funcionalidades adicionais do módulo -------------
   registerDynamicTileConfig();
-  registerSortingConfig();
+  // registerSortingConfig();
   registerOcclusionConfig();
 
   
@@ -260,6 +261,7 @@ Hooks.on("renderTileConfig", initTileForm);
 Hooks.on("createTile", handleCreateTile);
 Hooks.on("updateTile", handleUpdateTile);
 Hooks.on("refreshTile", handleRefreshTile);
+// Hooks.on("getSceneControlButtons", addDepthSortControls);
 
 //autosorting
 Hooks.on("canvasReady", (canvas) => {isoDepthSortReady();})
@@ -296,7 +298,7 @@ Hooks.on('createToken', async (tokenDocument, options, userId) => {
  * @param {----- TESTING AREA / ÁREA DE TESTES -----}
 */
 // Wait for movement animation end
-// const anim = CanvasAnimation.getAnimation(token.animationName);
+// const anim = foundry.canvas.animation.CanvasAnimation.getAnimation(token.animationName);
 // if(anim?.promise) await anim.promise;
 
 /*

--- a/scripts/main.js
+++ b/scripts/main.js
@@ -27,7 +27,7 @@ import {
 
 import {
   isoDepthSort,
-  isoDepthSortReady,
+  isoDepthSortMixin
 } from './autosorting.js'
 
 import { registerDynamicTileConfig, increaseTilesOpacity, decreaseTilesOpacity } from './dynamictile.js';
@@ -172,7 +172,6 @@ Hooks.once("init", function() {
   });
 
   // ------------- Registra os atalhos do módulo ------------- 
-  
   game.keybindings.register(isometricModuleConfig.MODULE_ID, 'increaseTilesOpacity', {
     name: game.i18n.localize('isometric-perspective.keybindings_increase_tile_opacity'), //name: 'Increase Tile Opacity',
     hint: game.i18n.localize('isometric-perspective.keybindings_increase_tile_opacity_hint'), //hint: 'Increases the opacity of always visible tiles.',
@@ -201,13 +200,11 @@ Hooks.once("init", function() {
     precedence: CONST.KEYBINDING_PRECEDENCE.NORMAL
   });
 
-
   // ------------- Executa os hooks de funcionalidades adicionais do módulo -------------
   registerDynamicTileConfig();
   // registerSortingConfig();
   registerOcclusionConfig();
 
-  
   // Define global debug print variable
   if (game.settings.get(isometricModuleConfig.MODULE_ID, "debug"))
     isometricModuleConfig.DEBUG_PRINT = true;
@@ -221,12 +218,9 @@ Hooks.once("init", function() {
   registerRuler();
 });
 
-
-// Verifica se deve mostrar a tela de boas-vindas
-// Checks whether to show the welcome screen
-
 //HOOKS REGISTRATION 
-
+  // Verifica se deve mostrar a tela de boas-vindas
+  // Checks whether to show the welcome screen
 // WelcomeScreen
 Hooks.once('ready', addWelcomeScreen);
 //scene configuration
@@ -261,38 +255,13 @@ Hooks.on("renderTileConfig", initTileForm);
 Hooks.on("createTile", handleCreateTile);
 Hooks.on("updateTile", handleUpdateTile);
 Hooks.on("refreshTile", handleRefreshTile);
-// Hooks.on("getSceneControlButtons", addDepthSortControls);
+Hooks.on("getSceneControlButtons", addDepthSortControls);
 
 //autosorting
-Hooks.on("canvasReady", (canvas) => {isoDepthSortReady();})
-Hooks.on("refreshToken", (token) => {
-  const scene = token.scene || token.document.parent || canvas.scene;
-  if(isIsometricAutosortingEnabledForPlaceable(token,scene)){
-    if (!token.document.isOwner) return;
-    isoDepthSort(token,scene,"Token");
-  }
-})
-Hooks.on('updateToken', async (tokenDocument, change, options, userId) => {
-  const scene = tokenDocument.parent;
-  const token = canvas.tokens.get(tokenDocument.id);
-  if(isIsometricAutosortingEnabledForPlaceable(token,scene)){
-    // Check if there has been a change in position
-    if ((change.x !== undefined || change.y !== undefined) && userId === game.userId) {
-      if (token) await isoDepthSort(token,scene,"Token");
-    }
-  }
+Hooks.on("init", () => {
+  CONFIG.Token.objectClass = isoDepthSortMixin(CONFIG.Token.objectClass);
+  // CONFIG.Tile.objectClass = isoDepthSortMixin(CONFIG.Tile.objectClass); // will need probably its own type of mixin the logic is too different
 });
-Hooks.on('createToken', async (tokenDocument, options, userId) => {
-  const scene = tokenDocument.parent;
-  const token = canvas.tokens.get(tokenDocument.id);
-  if(isIsometricAutosortingEnabledForPlaceable(token,scene)){
-    // If the movement is from the current user
-    if (userId === game.userId) {
-      if (token) await isoDepthSort(token,scene,"Token");
-    }
-  }
-});
-
 
 /**
  * @param {----- TESTING AREA / ÁREA DE TESTES -----}

--- a/scripts/main.js
+++ b/scripts/main.js
@@ -118,6 +118,16 @@ Hooks.once("init", function() {
     requiresReload: true
   });
 
+  game.settings.register(isometricModuleConfig.MODULE_ID, "depthSortActiveFlag", {
+    name: game.i18n.localize('isometric-perspective.settings_toggle_depth_sort_active'), //name: 'Toggle depth sorting',
+    hint: game.i18n.localize('isometric-perspective.settings_toggle_depth_sort_active_hint'), //hint: 'Toggle depth sorting for newly created tiles while active',
+    scope: 'world',
+    config: false,
+    default: false,
+    type: Boolean,
+    requiresReload: false
+  });
+
   /*
   game.settings.register(isometricModuleConfig.MODULE_ID, 'enableOcclusionTokenSilhouette', {
     name: game.i18n.localize('isometric-perspective.settings_token_silhouette_name'), //name: 'Enable Occlusion: Token Silhouette',
@@ -255,7 +265,9 @@ Hooks.on("renderTileConfig", initTileForm);
 Hooks.on("createTile", handleCreateTile);
 Hooks.on("updateTile", handleUpdateTile);
 Hooks.on("refreshTile", handleRefreshTile);
-Hooks.on("getSceneControlButtons", addDepthSortControls);
+Hooks.on("getSceneControlButtons", controls => {
+  addDepthSortControls(controls);
+});
 
 //autosorting
 Hooks.on("init", () => {

--- a/scripts/tile.js
+++ b/scripts/tile.js
@@ -35,7 +35,6 @@ export function initTileForm(app, html, context, options){
   });
 
   //Dynamic tile and wall linking
-
   const selectWallButton = html.querySelector('.select-wall');
   const clearWallButton = html.querySelector('.clear-wall');
   const linkedWallsIdInput = html.querySelector('input[name="flags.isometric-perspective.linkedWallIds"]');
@@ -115,7 +114,7 @@ export function handleUpdateTile(tileDocument, updateData, options, userId) {
 
   if (isTileSortable){
     tile.mesh.sortLayer = foundry.canvas.groups.PrimaryCanvasGroup.SORT_LAYERS.TOKENS; 
-    tile.mesh.sort = comparePlaceablePosition(tile, true); // need a fix
+    tile.mesh.sort = comparePlaceablePosition(tile, true);
   }
 
 }
@@ -130,12 +129,11 @@ export function handleRefreshTile(tile) {
 
   if (isTileSortable){
     tile.mesh.sortLayer = foundry.canvas.groups.PrimaryCanvasGroup.SORT_LAYERS.TOKENS; 
-    tile.mesh.sort = comparePlaceablePosition(tile, true); // need a fix
+    tile.mesh.sort = comparePlaceablePosition(tile, true);
   }
 }
 
 export function addDepthSortControls(controls){
-  //stuff
   controls.tiles.tools.toggleDetphSort = {
     name:" toggle depth sort",
     icon: "fa-solid fa-sort",
@@ -143,9 +141,7 @@ export function addDepthSortControls(controls){
     button: true,
     visible: game.user.isGM,
     onChange: () => {
-      // game.settings.get(isometricModuleConfig.MODULE_ID, "showWelcome")
-      
-      
+      // game.settings.get(isometricModuleConfig.MODULE_ID, "toggleTileDepthSort")
     }
   }
 }

--- a/scripts/tile.js
+++ b/scripts/tile.js
@@ -133,5 +133,21 @@ export function handleRefreshTile(tile) {
     tile.mesh.sort = comparePlaceablePosition(tile, true); // need a fix
   }
 }
+
+export function addDepthSortControls(controls){
+  //stuff
+  controls.tiles.tools.toggleDetphSort = {
+    name:" toggle depth sort",
+    icon: "fa-solid fa-sort",
+    order: Object.keys(controls.tokens.tools).length,
+    button: true,
+    visible: game.user.isGM,
+    onChange: () => {
+      // game.settings.get(isometricModuleConfig.MODULE_ID, "showWelcome")
+      
+      
+    }
+  }
+}
   
   

--- a/scripts/tile.js
+++ b/scripts/tile.js
@@ -93,6 +93,13 @@ export function handleCreateTile(tileDocument) {
   const scene = tile.scene;
   const isSceneIsometric = scene.getFlag(isometricModuleConfig.MODULE_ID, "isometricEnabled");
   requestAnimationFrame(() => applyIsometricTransformation(tile, isSceneIsometric));
+
+  const isDepthSortToggled = game.settings.get(isometricModuleConfig.MODULE_ID, "depthSortActiveFlag");
+  if(isDepthSortToggled){
+    tile.document.setFlag(isometricModuleConfig.MODULE_ID,"isoTileAutoSortingEnabled", true);
+  } else {
+    tile.document.setFlag(isometricModuleConfig.MODULE_ID,"isoTileAutoSortingEnabled", false);
+  }
 }
 
 export function handleUpdateTile(tileDocument, updateData, options, userId) {
@@ -134,14 +141,15 @@ export function handleRefreshTile(tile) {
 }
 
 export function addDepthSortControls(controls){
-  controls.tiles.tools.toggleDetphSort = {
-    name:" toggle depth sort",
+  controls.tiles.tools.toggleDephtSort = {
+    name:"toggleDephtSort",
+    title:"Toggle depth sort",
     icon: "fa-solid fa-sort",
-    order: Object.keys(controls.tokens.tools).length,
-    button: true,
+    order: Object.keys(controls.tiles.tools).length,
+    toggle: true,
     visible: game.user.isGM,
-    onChange: () => {
-      // game.settings.get(isometricModuleConfig.MODULE_ID, "toggleTileDepthSort")
+    onChange: (event,toggled) => {
+      game.settings.set(isometricModuleConfig.MODULE_ID, "depthSortActiveFlag",toggled);
     }
   }
 }

--- a/scripts/transform.js
+++ b/scripts/transform.js
@@ -225,9 +225,13 @@ export function applyBackgroundTransformation(scene, isSceneIsometric, shouldTra
       scale,
       scale * ISOMETRIC_CONST.ratio // Math.sqrt(3)
     );
-    
+    let isoScene = null;
     // Calculate scene dimensions and padding
-    const isoScene = canvas.scene;
+    if (game.release.generation < 14) {
+      isoScene = canvas.background; // for v13 and under
+    } else {
+      isoScene = canvas.level; // scene.background was deprecated in v14
+    }
     const padding = isoScene.padding;
     const paddingX = isoScene.width * padding;
     const paddingY = isoScene.height * padding;

--- a/scripts/utils.js
+++ b/scripts/utils.js
@@ -69,19 +69,15 @@ function getDecimalPrecision(step) {
 
 export function patchConfig(documentSheet, config, args) {
   if (!documentSheet) return;
-  
   // Check if already patched
   if (documentSheet.TABS?.sheet?.tabs?.some(tab => tab.id === config.tabId)) return;
-  
   // Adding the isometric tab data to the config parts
   if (documentSheet.TABS?.sheet?.tabs) {
     documentSheet.TABS.sheet.tabs.push({ id: config.tabId, group: config.tabGroup, label:config.label, icon: config.icon });
   }
-  
   // Adding the part template
   if (documentSheet.PARTS) {
     documentSheet.PARTS.isometric = {template: config.templatePath};
-
     // Re-order footer to be last
     if (documentSheet.PARTS.footer) {
       const footerPart = documentSheet.PARTS.footer;
@@ -100,9 +96,7 @@ export function patchConfig(documentSheet, config, args) {
         console.warn("Isometric Perspective: Unable to access token document");
         return { tab: context.tabs?.[partId] };
       }
-      
       const flags = doc.flags?.[config.moduleConfig.MODULE_ID] ?? {};
-
       return {
         ...flags,
         ...args,

--- a/scripts/utils.js
+++ b/scripts/utils.js
@@ -116,13 +116,9 @@ export function patchConfig(documentSheet, config, args) {
 
 //to avoid duplicate security checkers all over the place
 export function isIsometricAutosortingEnabledForPlaceable(placeable,scene) {
-  const isometricWorldEnabled = game.settings.get(isometricModuleConfig.MODULE_ID, "worldIsometricFlag");
-  const enableAutoSorting = game.settings.get(isometricModuleConfig.MODULE_ID, "enableAutoSorting");
-  if (!isometricWorldEnabled || !enableAutoSorting) return;
-  if (game.version.startsWith("11")) return; //There isn't a sort method on v11. Needs another way to sort.
+  if (game.version.startsWith("11")) return false; //There isn't a sort method on v11. Needs another way to sort.
   if (!scene) return false;
-  if (!scene.getFlag(isometricModuleConfig.MODULE_ID, "isometricEnabled")) {return false}
-  else { return true};
+  if (scene.getFlag(isometricModuleConfig.MODULE_ID, "isometricEnabled")) {return true}
 }
 
 /**

--- a/scripts/utils.js
+++ b/scripts/utils.js
@@ -168,10 +168,10 @@ export function createAdjustableButton(options) {
       inputs,                   // Array of input elements to update [InputX, InputY]
       adjustmentScale = 0.1,    // Scale factor or Function returning [scaleX, scaleY]
       valueConstraints = null,  // Optional min/max constraints {min, max}
-      roundingPrecision = 0,     // Number of decimal places
-      onInputCallback = null,    // Optional callback after input update
-      onDragStart = null,        // Optional callback on drag start
-      onDragEnd = null           // Optional callback on drag end
+      roundingPrecision = 0,    // Number of decimal places
+      onInputCallback = null,   // Optional callback after input update
+      onDragStart = null,       // Optional callback on drag start
+      onDragEnd = null          // Optional callback on drag end
   } = options;
 
   if (!buttonElement) return;

--- a/templates/tile-config.hbs
+++ b/templates/tile-config.hbs
@@ -4,11 +4,11 @@
         <label for="{{rootId}}-isometric-perspective-enable-tile-enable-isometrics">{{localize 'isometric-perspective.tile_enableIsometric_name'}}</label>
         <input id="{{rootId}}-isometric-perspective-enable-tile-enable-isometrics" type="checkbox" name="flags.isometric-perspective.isoTileDisabled" {{checked document.flags.isometric-perspective.isoTileDisabled}}>
     </div>
-        <div class="form-group">
+    <p class="hint">{{localize 'isometric-perspective.tile_enableIsometric_hint'}}</p>
+    <div class="form-group">
         <label for="{{rootId}}-isometric-perspective-enable-tile-enable-isometrics-tile-sorting">{{localize 'isometric-perspective.tile_enableIsometric_sorting_name'}}</label>
         <input id="{{rootId}}-isometric-perspective-enable-tile-enable-isometrics-tile-sorting" type="checkbox" name="flags.isometric-perspective.isoTileAutoSortingEnabled" {{checked document.flags.isometric-perspective.isoTileAutoSortingEnabled}}>
     </div>
-    <p class="hint">{{localize 'isometric-perspective.tile_enableIsometric_hint'}}</p>
     <div class="form-group offset-point">
         <label>{{localize 'isometric-perspective.tile_artOffset_name'}}</label>
         <div class="form-fields">


### PR DESCRIPTION
added a togglable depth sort button in the tile tools UI 
<img width="342" height="384" alt="image" src="https://github.com/user-attachments/assets/539a2f8e-653b-4711-80fb-2dd315f2d8b6" />

while enabled , any tiles added to the canvas will have depth sorting enabled :
<img width="1351" height="847" alt="image" src="https://github.com/user-attachments/assets/4c18431c-9885-48aa-8c93-2ffd57a2663d" />
 which make the whole process of building depth sorted scene much simpler and easier, still keeping the config checkbox as an extra option for tweaking purpose in case later someone want to modify an unsorted tile or revert it back to a normal tile.

fixed also a few bugs and a small memory leak issue 

known issue : 
<img width="459" height="169" alt="image" src="https://github.com/user-attachments/assets/22e39928-b4ba-4a00-b3b6-73d762520b59" />

still couldnt find what cause this or even if its related to the module itself, it seems to only happens when the module is active, so its likely to be the case, however its not currently causing any visible issue or noticable performances issues. More investigating is required.