### PR TITLE
two hotfixes and cleanup

### DIFF
--- a/scripts/autosorting.js
+++ b/scripts/autosorting.js
@@ -24,8 +24,10 @@ export function isoDepthSortTileMixin(Base){
     }
     _onUpdate(changed, options, userId) {
       super._onUpdate(changed, options, userId);
-      this.zIndex = 0;
-      this.mesh.zIndex = 0;
+      if(this.zIndex){
+        this.zIndex = 0;
+        this.mesh.zIndex = 0;
+      }
       const isTileSortable = this.document.getFlag(isometricModuleConfig.MODULE_ID, 'isoTileAutoSortingEnabled');
       if(isTileSortable){
       if ("y" in changed || "x" in changed) {
@@ -39,6 +41,7 @@ export function isoDepthSortTileMixin(Base){
           this.mesh.parent.sortDirty = true;
         }
       }
+      
 
     }
   }
@@ -74,7 +77,7 @@ export function isoDepthSortTokenMixin(Base){
         currentSprite.object.document.sort = i;
         currentSprite.sort = i;
       }
-      debugCanvasLayer(this.sortList)
+      // debugCanvasLayer(this.sortList)
       this.mesh.parent.sortDirty = true;
     }
 

--- a/scripts/autosorting.js
+++ b/scripts/autosorting.js
@@ -10,8 +10,10 @@ export function isoDepthSortTileMixin(Base){
     _refreshState() {
       super._refreshState();
       //prevent mesh flickering on hover or controlled
-      this.zIndex = 0;
-      this.mesh.zIndex = 0;
+      if(this.zIndex){
+        this.zIndex = 0;
+        this.mesh.zIndex = 0;
+      }
 
       const isTileSortable = this.document.flags[isometricModuleConfig.MODULE_ID]?.isoTileAutoSortingEnabled || false;
       if (isTileSortable){

--- a/scripts/utils.js
+++ b/scripts/utils.js
@@ -191,37 +191,37 @@ function compareSpriteByPosition(sprite,sibling){
 
 function sortByX(spriteA , spriteB){
   let result = 1;
-  if ( spriteA.name === "orc fighter" || spriteB.name === "orc fighter") {
-    console.log("orc fighter sorted by X")
-  }
+  // if ( spriteA.name === "orc fighter" || spriteB.name === "orc fighter") {
+  //   console.log("orc fighter sorted by X")
+  // }
   if (spriteA.x >= spriteB.x) { result = -1;}
   return result;
 }
 
 function sortByY(spriteA , spriteB){
   let result = 1;
-  if ( spriteA.name === "orc fighter" || spriteB.name === "orc fighter") {
-    console.log("orc fighter sorted by Y")
-  }
+  // if ( spriteA.name === "orc fighter" || spriteB.name === "orc fighter") {
+  //   console.log("orc fighter sorted by Y")
+  // }
   if (spriteA.y <= spriteB.y) { result = -1;}
   else {result = 1;}
-  console.log("sprite", spriteA.name,spriteA.y, spriteB.name, spriteA.y,result)
+  // console.log("sprite", spriteA.name,spriteA.y, spriteB.name, spriteA.y,result)
   return result;
 }
 
 function isRegionMatching (sprite, sibling){
   if(sprite.occupiedRegion !== null && sibling.linkedRegion !== null){
     if(sprite.occupiedRegion === sibling.linkedRegion){
-      if ( sprite.name === "orc fighter" || sibling.name === "orc fighter") {
-        console.log("orc fighter sorted by REGION")
-      }
+      // if ( sprite.name === "orc fighter" || sibling.name === "orc fighter") {
+      //   console.log("orc fighter sorted by REGION")
+      // }
       return true
     }
   } else if(sibling.occupiedRegion !== null && sprite.linkedRegion !== null){
     if(sibling.occupiedRegion === sprite.linkedRegion){
-      if ( sprite.name === "orc fighter" || sibling.name === "orc fighter") {
-        console.log("orc fighter sorted by REGION")
-      }
+      // if ( sprite.name === "orc fighter" || sibling.name === "orc fighter") {
+      //   console.log("orc fighter sorted by REGION")
+      // }
       return true
     }
   } else {

--- a/scripts/utils.js
+++ b/scripts/utils.js
@@ -418,14 +418,14 @@ function sortableSprite(sprite){
   const y = sprite.object.document.y;
   let anchorX = sprite.object.document.x;
   let anchorY = sprite.object.document.y;
-  const tileMirrorHorizontal = sprite.object.document.getFlag(fastFlipCompatiility.MODULE_ID, fastFlipCompatiility.TILE_MIRROR_HORIZONTAL)?sprite.object.document.getFlag(fastFlipCompatiility.MODULE_ID, fastFlipCompatiility.TILE_MIRROR_HORIZONTAL) : null;
+  let tileMirrorHorizontal = null;
+  
+  if (game.modules.get(fastFlipCompatiility.MODULE_ID)?.active){
+    tileMirrorHorizontal = sprite.object.document.getFlag(fastFlipCompatiility.MODULE_ID, fastFlipCompatiility.TILE_MIRROR_HORIZONTAL)
+  }
+
   const tileFlipped = sprite.object.document.getFlag(isometricModuleConfig.MODULE_ID, 'tileFlipped')?sprite.object.document.getFlag(isometricModuleConfig.MODULE_ID,'tileFlipped') : null;
-
-  // if(sprite.object.document.documentName === "Tile"){
-  //   anchorX = (sprite.object.document.x) - (sprite.object.document.width * 0.5);
-  //   anchorY = (sprite.object.document.y) + (sprite.object.document.height * 0.5);
-  // }
-
+  
   const height = sprite.object.document.height;
   const width = sprite.object.document.width;
   let newLinkedRegion = sprite.object.document.getFlag(isometricModuleConfig.MODULE_ID, 'regionLink');
@@ -460,10 +460,6 @@ export function debugCanvasLayer(spriteList){
     spriteList.map(sprite => {
       let anchorX = sprite.object.document.x;
       let anchorY = sprite.object.document.y;
-      // if(sprite.object.document.documentName === "Tile"){
-      //   anchorX = (sprite.object.document.x) - (sprite.object.document.width * 0.25)
-      //   anchorY = (sprite.object.document.y) + (sprite.object.document.height * 0.25)
-      // }
 
       let newLinkedRegion = sprite.object.document.getFlag(isometricModuleConfig.MODULE_ID, 'regionLink');
       let newOccupiedRegion = sprite.object.document.getFlag(isometricModuleConfig.MODULE_ID, 'currentRegion');
@@ -472,16 +468,16 @@ export function debugCanvasLayer(spriteList){
       data.push({
         // id: sprite.object.document.id,
         // type: sprite.object.document.documentName,
-        name: sprite.object.document.name? sprite.object.document.name : "no name",
+        // name: sprite.object.document.name? sprite.object.document.name : "no name",
         //sprite.documentName === "Tile"? (sprite.x) - (sprite.width *0.25) : sprite.x,
-        x: anchorX,
-        y: anchorY,
+        // x: anchorX,
+        // y: anchorY,
         // sortLayer: sprite.sortLayer, 
-        sort: sprite.sort,
+        // sort: sprite.sort,
         // linkedRegion:newLinkedRegion,
         // occupiedRegion: newOccupiedRegion,
         // occupiedRegion: sprite.object.document.getFlag(isometricModuleConfig.MODULE_ID, 'currentRegion')? sprite.object.document.getFlag(isometricModuleConfig.MODULE_ID, 'currentRegion') : "none",
-        tileMirrorHorizontal: sprite.object.document.getFlag(fastFlipCompatiility.MODULE_ID, fastFlipCompatiility.TILE_MIRROR_HORIZONTAL)?sprite.object.document.getFlag(fastFlipCompatiility.MODULE_ID, fastFlipCompatiility.TILE_MIRROR_HORIZONTAL) : null,
+        // tileMirrorHorizontal: sprite.object.document.getFlag(fastFlipCompatiility.MODULE_ID, fastFlipCompatiility.TILE_MIRROR_HORIZONTAL)?sprite.object.document.getFlag(fastFlipCompatiility.MODULE_ID, fastFlipCompatiility.TILE_MIRROR_HORIZONTAL) : null,
         // tileFlipped: sprite.object.document.getFlag(isometricModuleConfig.MODULE_ID, 'tileFlipped')?sprite.object.document.getFlag(isometricModuleConfig.MODULE_ID,'tileFlipped') : null,
       })
     });

--- a/scripts/utils.js
+++ b/scripts/utils.js
@@ -119,7 +119,7 @@ export function sortPlaceableByPosition(placeable) {
     const currentSortLayer = placeable.mesh.parent
     return canvasLayer
     .filter( sprite => sprite.sortLayer === placeableMeshLayer)
-    .sort((sprite,sibling)=> compareSpriteByPosition(sprite,sibling));
+    .toSorted((sprite,sibling)=> compareSpriteByPosition(sprite,sibling));
   }
 }
 
@@ -128,10 +128,9 @@ export function sortPlaceableByRegion(placeable) {
     const placeableMeshLayer = foundry.canvas.groups.PrimaryCanvasGroup.SORT_LAYERS.TOKENS;
     const canvasLayer = canvas.primary.children;
     const currentSortLayer = placeable.mesh.parent
-
-    const displayList = canvasLayer.filter( sprite => sprite.sortLayer === placeableMeshLayer);
-    
-    return displayList.toSorted((sprite,sibling)=> {
+    return canvasLayer
+    .filter( sprite => sprite.sortLayer === placeableMeshLayer)
+    .toSorted((sprite,sibling)=> {
       let compare = 0;
       if( sprite.object.document.documentName === "Token" || sibling.object.document.documentName === "Token" ) {
         if(sprite.object.document.getFlag(isometricModuleConfig.MODULE_ID, 'currentRegion')){
@@ -192,12 +191,18 @@ function compareSpriteByPosition(sprite,sibling){
 
 function sortByX(spriteA , spriteB){
   let result = 1;
+  if ( spriteA.name === "orc fighter" || spriteB.name === "orc fighter") {
+    console.log("orc fighter sorted by X")
+  }
   if (spriteA.x >= spriteB.x) { result = -1;}
   return result;
 }
 
 function sortByY(spriteA , spriteB){
   let result = 1;
+  if ( spriteA.name === "orc fighter" || spriteB.name === "orc fighter") {
+    console.log("orc fighter sorted by Y")
+  }
   if (spriteA.y <= spriteB.y) { result = -1;}
   else {result = 1;}
   console.log("sprite", spriteA.name,spriteA.y, spriteB.name, spriteA.y,result)
@@ -206,9 +211,19 @@ function sortByY(spriteA , spriteB){
 
 function isRegionMatching (sprite, sibling){
   if(sprite.occupiedRegion !== null && sibling.linkedRegion !== null){
-    if(sprite.occupiedRegion === sibling.linkedRegion){return true}
+    if(sprite.occupiedRegion === sibling.linkedRegion){
+      if ( sprite.name === "orc fighter" || sibling.name === "orc fighter") {
+        console.log("orc fighter sorted by REGION")
+      }
+      return true
+    }
   } else if(sibling.occupiedRegion !== null && sprite.linkedRegion !== null){
-    if(sibling.occupiedRegion === sprite.linkedRegion){return true}
+    if(sibling.occupiedRegion === sprite.linkedRegion){
+      if ( sprite.name === "orc fighter" || sibling.name === "orc fighter") {
+        console.log("orc fighter sorted by REGION")
+      }
+      return true
+    }
   } else {
     return false;
   }


### PR DESCRIPTION
missed a few console logs i forgot to comment out, also found two cases where the canvas crash 
- if a tile for some reason dosent have a zIndex it would crash the canvas 
- the compatibility fix for fast-flip was not checking correctly if the module was active and caused crashes on setups that do not have it enabled
this hotfix also clear this bug : https://github.com/arlosmolten/isometric-perspective/issues/43