### PR TITLE
v14 hotfix - 01

### DIFF
--- a/scripts/main.js
+++ b/scripts/main.js
@@ -284,15 +284,18 @@ Hooks.once("init", function () {
   else isometricModuleConfig.WORLD_ISO_FLAG = false;
 
   isometricModuleConfig.CONST = parseInt(game.version.split(".")[0]); // Extrai a versão principal
-  registerRuler();
+  // registerRuler(); // testing registering the ruler in the setup hook instead , keeping this in case if a revert is needed
 });
 
 //HOOKS REGISTRATION
 
+// Ruler
+Hooks.on("setup",registerRuler);
 // WelcomeScreen
 Hooks.once("ready", addWelcomeScreen);
 //scene configuration
 Hooks.on("ready", createSceneIsometricTab);
+Hooks.on("ready", applyDepthSort);
 
 //scene management
 Hooks.on("renderSceneConfig", initSceneForm);
@@ -334,8 +337,6 @@ Hooks.on("getSceneControlButtons", (controls) => {
 Hooks.on("init", () => {
   CONFIG.Token.objectClass = isoDepthSortTokenMixin(CONFIG.Token.objectClass);
   CONFIG.Tile.objectClass = isoDepthSortTileMixin(CONFIG.Tile.objectClass);
-  // console.log("CONFIG.Tile", CONFIG)
-  // CONFIG.TileConfig.objectClass = isoTilePaletteMixin(CONFIG.TileConfig.objectClass);
 });
 
 /**

--- a/scripts/tile.js
+++ b/scripts/tile.js
@@ -209,8 +209,6 @@ export function handleCreateTile(tileDocument) {
     "depthSortActiveFlag",
   );
 
-  console.log("isDepthSortEnabled", isDepthSortEnabled);
-
   if (isDepthSortEnabled) {
     tile.document.setFlag(
       isometricModuleConfig.MODULE_ID,
@@ -334,10 +332,21 @@ export function createTileIsometricPaletteConfig(app, html, data){
     blank: ""
   });
 
+  const enableDepthSortCheckbox = foundry.applications.fields.createCheckboxInput({
+    name: `flags.${scope}.isoTileAutoSortingEnabled`,
+    value: doc.getFlag(scope, "isoTileAutoSortingEnabled" ?? false),
+  });
+
   // form groups
   const offsetGroup = foundry.applications.fields.createFormGroup({ 
     input:[offsetYInputLabel,offsetXInput,offsetXInputLabel,offsetYInput,], 
     label: "isometric-perspective.tile_artOffset_name", 
+    localize: true
+  });
+
+  const depthSortGroup = foundry.applications.fields.createFormGroup({ 
+    input:[enableDepthSortCheckbox], 
+    label: "isometric-perspective.tile_enableIsometric_sorting_name", 
     localize: true
   });
 
@@ -348,6 +357,7 @@ export function createTileIsometricPaletteConfig(app, html, data){
   });
 
   videoSection.insertAdjacentElement("afterend", facingGroup);
+  videoSection.insertAdjacentElement("afterend", depthSortGroup);
   videoSection.insertAdjacentElement("afterend", offsetGroup);
   
 }

--- a/scripts/utils.js
+++ b/scripts/utils.js
@@ -185,10 +185,17 @@ export class SortableSprite {
       this.name = placeable.object.document.name
         ? placeable.object.document.name
         : "no name";
-      this.x = placeable.object.document.x;
-      this.y = placeable.object.document.y;
+        
       this.width = placeable.object.mesh.width ?? 0;
       this.height = placeable.object.mesh.height ?? 0;
+      this.x = placeable.object.document.x;
+      this.y = placeable.object.document.y;
+
+      // if (game.release.generation < 14) {
+      //   this.x = this.x - (this.height * 0.5);
+      //   this.y = this.y - (this.width * 0.5);
+      // }
+
       this.isoDepth = (this.y - this.x) * 0.5;
       this.facing =
         placeable.object.document.getFlag(


### PR DESCRIPTION
- added a fix that caused a conflict with lancer speed provider and broke the ruler tool when both mods were used together
- added the depth sort checkbox to the tile palette ( found a good use case that make v14 migration a smoother experience )