### PR TITLE
Warpspeednyancat v14 patch 1.1

### DIFF
--- a/scripts/autosorting.js
+++ b/scripts/autosorting.js
@@ -17,8 +17,10 @@ export function isoDepthSortTileMixin(Base) {
           foundry.canvas.groups.PrimaryCanvasGroup.SORT_LAYERS.TOKENS;
           applyDepthSort();
       } else {
-        this.mesh.sortLayer =
-          foundry.canvas.groups.PrimaryCanvasGroup.SORT_LAYERS.TILES;
+        if(this.mesh){
+          this.mesh.sortLayer =
+            foundry.canvas.groups.PrimaryCanvasGroup.SORT_LAYERS.TILES;
+        }
       }
     }
     _onUpdate(changed, options, userId) {

--- a/scripts/autosorting.js
+++ b/scripts/autosorting.js
@@ -15,6 +15,7 @@ export function isoDepthSortTileMixin(Base) {
       if (isTileSortable) {
         this.mesh.sortLayer =
           foundry.canvas.groups.PrimaryCanvasGroup.SORT_LAYERS.TOKENS;
+          applyDepthSort();
       } else {
         this.mesh.sortLayer =
           foundry.canvas.groups.PrimaryCanvasGroup.SORT_LAYERS.TILES;

--- a/scripts/tile.js
+++ b/scripts/tile.js
@@ -301,8 +301,8 @@ export function createTileIsometricPaletteConfig(app, html, data){
   const offsetXInputLabel = document.createElement("label");
   offsetXInputLabel.innerHTML = '<label>X</label>'
   
-  const offsetXInput = foundry.applications.fields.createNumberInput({
-    name: `flags.${scope}."offsetY"`, 
+  const offsetYInput = foundry.applications.fields.createNumberInput({
+    name: `flags.${scope}.offsetY`, 
     value:doc.getFlag(scope, "offsetY") ?? 0 
   });
 
@@ -310,10 +310,12 @@ export function createTileIsometricPaletteConfig(app, html, data){
   const offsetYInputLabel = document.createElement("label");
   offsetYInputLabel.innerHTML = '<label>Y</label>'
 
-  const offsetYInput = foundry.applications.fields.createNumberInput({
-    name:`flags.${scope}.offsetX`, 
+  const offsetXInput = foundry.applications.fields.createNumberInput({
+    name:`flags.${scope}.offsetX`,
     value:doc.getFlag(scope, "offsetX") ?? 0 
   });
+
+  console.log("offsetY", doc.getFlag(scope, "offsetY"))
 
   // tileFacing input config
   const tileFacings = TILE_FACINGS.map((obj) => obj.facing);
@@ -357,7 +359,7 @@ export function createTileIsometricPaletteConfig(app, html, data){
   });
 
   videoSection.insertAdjacentElement("afterend", facingGroup);
-  videoSection.insertAdjacentElement("afterend", depthSortGroup);
   videoSection.insertAdjacentElement("afterend", offsetGroup);
+  videoSection.insertAdjacentElement("afterend", depthSortGroup);
   
 }


### PR DESCRIPTION
3 bug fixes:

- fixed a case where autosorting was not applied when creating a tile or loading a scene that isn't cached
- fixed a crash when creating a tile manually rather than with the image import tool
- fixed the x offset field who was not updating the tile X offset properly in the tile palette.